### PR TITLE
Fix wave manager parameter naming

### DIFF
--- a/GameProto/WaveManager.cpp
+++ b/GameProto/WaveManager.cpp
@@ -6,11 +6,11 @@
 #include <ctime>
 
 //constructor
-WaveManager::WaveManager(int BasePerWave, float intercalSec, Player* player)
+WaveManager::WaveManager(int BasePerWave, float intervalSec, Player* player)
 	: m_WaveCount(0)
 	, m_Timer(0.0f)
 	, m_BasePerWave(BasePerWave)
-	, m_Interval(intercalSec)
+    , m_Interval(intervalSec)
 	, m_pPlayer(player)
 {
 	std::srand(static_cast<unsigned int>(std::time(nullptr))); // Seed the random number generator

--- a/GameProto/WaveManager.h
+++ b/GameProto/WaveManager.h
@@ -8,7 +8,7 @@ class Player;
 class WaveManager
 {
 public:
-	WaveManager(int basePerWave, float intercalSec, Player* player);
+    WaveManager(int basePerWave, float intervalSec, Player* player);
 	~WaveManager();
 	WaveManager(const WaveManager& other);
 	WaveManager& operator=(const WaveManager& other);


### PR DESCRIPTION
## Summary
- rename `intercalSec` parameter to `intervalSec`
- update constructor implementation accordingly

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685fdae609948320a74d02536f991ebc